### PR TITLE
Bump leaky-bucket to 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.8"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 histogram = "0.6"
-leaky-bucket = "0.10"
+leaky-bucket = "0.12.1"
 async-trait = "0.1"
 bytesize = "1.0"
 humantime = "2.0"

--- a/src/bench_run.rs
+++ b/src/bench_run.rs
@@ -100,10 +100,7 @@ impl BenchRun {
         let client = bench_protocol_adapter.build_client()?;
 
         while self.has_more_work() {
-            self.rate_limiter
-                .acquire_one()
-                .await
-                .expect("Unexpected LeakyBucket.acquire error");
+            self.rate_limiter.acquire_one().await;
 
             if STOP_ON_FATAL.load(Ordering::Relaxed) {
                 break;


### PR DESCRIPTION
Was looking over users of leaky-bucket and what's preventing people from upgrading. So I setup this PR to bump it for you (if you want).

Coordinator background task is no longer needed.

RateLimiter no longer implements `Clone`, but this was achieved internally before using an `Arc` to track interior state, so this is done externally instead.