### PR TITLE
Fix correctness issues and improve rate limiter precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ derive_builder = "0.20"
 log = "0.4"
 log4rs = "1.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
 serde_json = "1.0"
 tokio = { version = "1.43", features = ["full"] }
 histogram = "1.5"
@@ -27,7 +26,6 @@ leaky-bucket = "1.1"
 async-trait = "0.1"
 bytesize = "1.3"
 humantime = "2.1"
-regex = "1.10"
 rand = "0.8"
 futures-util = "0.3"
 hyper = { version = "0.14", features = ["full"] }

--- a/src/http_bench_session.rs
+++ b/src/http_bench_session.rs
@@ -150,17 +150,19 @@ impl BenchmarkProtocolAdapter for HttpBenchAdapter {
 
                 let mut stream = r.into_body();
                 let mut total_size = 0;
+                let mut body_error = false;
                 while let Some(item) = stream.next().await {
                     if let Ok(bytes) = item {
                         total_size += bytes.len();
                     } else {
+                        body_error = true;
                         break;
                     }
                 }
                 RequestStatsBuilder::default()
                     .bytes_processed(total_size)
                     .status(status)
-                    .is_success(success)
+                    .is_success(success && !body_error)
                     .duration(Instant::now().duration_since(start))
                     .fatal_error(fatal_error)
                     .build()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,9 +5,9 @@ use histogram::Histogram;
 use log::{error, info};
 use serde::Serialize;
 use std::collections::HashMap;
+use std::io;
 use std::ops::AddAssign;
 use std::time::{Duration, Instant};
-use std::{cmp, io};
 
 pub trait HistogramStatsExt {
     fn minimum(&self) -> Option<u64>;
@@ -274,14 +274,7 @@ impl BenchRunReportItem {
             .map(|(k, v)| (k.clone(), *v))
             .collect();
 
-        pairs.sort_by(|a, b| {
-            let d = b.1 - a.1;
-            match d {
-                1..=0x7fffffff => cmp::Ordering::Greater,
-                0 => a.0.cmp(&b.0),
-                _ => cmp::Ordering::Less,
-            }
-        });
+        pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
         pairs
     }
@@ -471,7 +464,11 @@ impl DefaultConsoleReporter {
             duration,
             total_bytes,
             total_requests,
-            success_rate: successful_requests as f64 * 100. / total_requests as f64,
+            success_rate: if total_requests > 0 {
+                successful_requests as f64 * 100. / total_requests as f64
+            } else {
+                0.0
+            },
             rate_per_second: total_requests as f64 / duration.as_secs_f64(),
             bitrate_mbps: total_bytes as f64 / duration.as_secs_f64() * 8. / 1_000_000.,
             response_code_summary: BenchRunReportItem::summary_ordered(metrics),

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -34,8 +34,7 @@ impl RateLimiter {
             leaky_bucket: Some(Arc::new(
                 InnerRateLimiter::builder()
                     .initial(0)
-                    // to compensate overhead let's add a bit to the rate
-                    .refill((amount * 1.01) as usize)
+                    .refill(amount as usize)
                     .interval(interval)
                     .max(amount as usize * 100)
                     .build(),
@@ -60,14 +59,16 @@ impl RateLimiter {
 
     fn rate_to_refill_amount_and_duration(rate_per_second: f64) -> (f64, Duration) {
         if rate_per_second > 1. {
-            let mut rate = rate_per_second as usize;
-            let mut int_ms = 1000;
+            // Scale by 10 to preserve one decimal place of precision.
+            // E.g. 1.5 rps -> 15 per 10_000ms -> gcd -> 3 per 2000ms
+            let rate_scaled = (rate_per_second * 10.0).round() as usize;
+            let interval_scaled = 10_000_usize; // 10 * 1000ms
 
-            let gcd = RateLimiter::gcd(rate, int_ms);
-            rate /= gcd;
-            int_ms /= gcd;
+            let gcd = RateLimiter::gcd(rate_scaled, interval_scaled);
+            let amount = rate_scaled / gcd;
+            let interval_ms = interval_scaled / gcd;
 
-            (rate as f64, Duration::from_millis(int_ms as u64))
+            (amount as f64, Duration::from_millis(interval_ms as u64))
         } else {
             (
                 1.,


### PR DESCRIPTION
## Summary

Follow-up to #25. Fixes correctness issues and improves measurement precision.

### Changes

**Correctness**
- **Body read errors now mark request as failed** — previously, if the response body stream returned an error mid-read, the request was still counted as successful based on HTTP status code alone. Now `is_success = status_ok && !body_error`
- **Division by zero guard** — `success_rate` no longer produces `NaN` when `total_requests == 0`
- **Sort overflow fix** — replaced `b.1 - a.1` (which can overflow for `i32`) with idiomatic `.cmp().then_with()`

**Precision**
- **Removed 1% rate inflation bias** — `refill(amount * 1.01)` systematically overshoot the target rate by 1%. Removed
- **Fractional rate preservation** — rates like 1.5 rps were truncated to 1 rps (33% error). Now scales by 10x before GCD reduction to preserve one decimal place (1.5 rps → 3 tokens per 2000ms)

**Cleanup**
- Removed unused `serde_yaml` and `regex` dependencies

### Tests
All 27 tests pass ✅