### PR TITLE
feat: add HTTP/3 (QUIC) benchmarking support

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --features full --tests -- -D warnings
 
+      - name: Run cargo clippy (http3)
+        run: cargo clippy --features http3 --tests -- -D warnings
+
   rustfmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,8 @@ jobs:
       run: cargo test --verbose --features full
     - name: Run tests tls
       run: cargo test --verbose --features tls-native
+    - name: Build http3
+      run: cargo build --verbose --features http3
+    - name: Run tests http3
+      run: cargo test --verbose --features http3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,20 @@ hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
 http-body-util = "0.1"
 bytes = { version = "1", features = ["serde"] }
+futures-util = { version = "0.3", optional = true }
 prometheus = { version = "0.13", features = ["push"], default-features = false, optional = true }
 hyper-tls = {version = "0.6", default-features = false, optional = true }
 native-tls = {version = "0.2", default-features = false, optional = true }
 tokio-native-tls = {version = "0.3", default-features = false, optional = true }
 hyper-boring = {version = "5.0", default-features = false, optional = true }
 boring = {version = "5.1", default-features = false, optional = true }
+h3 = { version = "0.0.8", optional = true }
+h3-quinn = { version = "0.0.10", optional = true }
+quinn = { version = "0.11", default-features = false, features = ["rustls-ring", "runtime-tokio"], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"], optional = true }
+rustls-pki-types = { version = "1", optional = true }
+webpki-roots = { version = "0.26", optional = true }
+url = { version = "2", optional = true }
 
 [dev-dependencies]
 mockito = "1.5"
@@ -50,3 +58,4 @@ tls-native = ["tls", "native-tls", "tokio-native-tls"]
 tls-boring = ["tls", "hyper-boring", "boring"]
 full = ["report-to-prometheus", "tls-native"]
 full-boring = ["report-to-prometheus", "tls-boring"]
+http3 = ["h3", "h3-quinn", "quinn", "rustls", "rustls-pki-types", "webpki-roots", "futures-util", "url"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 Overview
 ========
 
-Benchmarking tool for network services. Currently, limited to HTTP only (H1 or H2, over TCP or TLS).
-However, it's easily extendable to other protocols.
+Benchmarking tool for network services. Currently supports HTTP (H1 or H2, over TCP or TLS)
+and HTTP/3 (over QUIC). It's easily extendable to other protocols.
 
 It works in the following modes:
 
@@ -60,12 +60,18 @@ Then:
 $ cargo install perf-gauge --features full
 ```
 
+To install with HTTP/3 (QUIC) support:
+```
+$ cargo install perf-gauge --features full,http3
+```
+
 Supported features:
 
 * `default` - if no features specified, only `http` traffic is supported
 * `tls-native` - TLS support (based on `OpenSSL`)
 * `tls-boring` - TLS support (based on `BoringSSL`). Doesn't support self-signed certs.
 * `report-to-prometheus` - to support `Prometheus` for metric collection
+* `http3` - HTTP/3 (QUIC) support via `quinn`/`rustls`. No OpenSSL dependency.
 * `full` - `report-to-prometheus` + `tls-native`
 * `full-boring` - `report-to-prometheus` + `tls-boring`
 
@@ -159,6 +165,8 @@ OPTIONS:
                                      \"Name:Value1:Value2:Value3\". In this case a random one is
                                      chosen for each request
         --http2_only                 Enforce HTTP/2 only
+        --http3                      Use HTTP/3 (QUIC). Requires https:// URLs
+                                     (needs --features http3)
         --ignore_cert                Allow self signed certificates
     -M, --method <METHOD>            Method. By default GET
     -V, --version                    Print version information
@@ -207,3 +215,28 @@ $ perf-gauge --concurrency 10 \
 * `--name nginx-direct` - the name of the test (used for reporting metrics to `prometheus`)
 * `--prometheus $PROMETHEUS_HOST:9091` - push-gateway `host:port` to send metrics to Prometheus.
 * `http http://local-nginx.org/10kb --conn_reuse` - run in `https` mode to the given endpoint, reusing connections and not checking the certificate. 
+
+HTTP/3 (QUIC) Benchmarking
+==========================
+
+HTTP/3 uses QUIC as its transport, providing lower latency connection establishment
+and built-in TLS 1.3. To benchmark an HTTP/3 endpoint:
+
+```bash
+$ perf-gauge --concurrency 10 \
+               --duration 1m \
+               http --http3 https://my-h3-service.com:443/endpoint
+```
+
+With rate control and self-signed certificates:
+
+```bash
+$ perf-gauge --concurrency 8 \
+               --rate 500 --rate_step 500 --rate_max 5000 \
+               --duration 1m \
+               http --http3 --ignore_cert https://localhost:8443/10kb
+```
+
+> **Note**: HTTP/3 requires `https://` URLs (QUIC always uses TLS).
+> The `--http3` flag cannot be combined with `--http2_only`.
+> Build with `--features http3` to enable this functionality.

--- a/src/bench_run.rs
+++ b/src/bench_run.rs
@@ -33,7 +33,7 @@ pub struct BenchRun {
 pub trait BenchmarkProtocolAdapter {
     type Client;
 
-    fn build_client(&self) -> Result<Self::Client, String>;
+    async fn build_client(&self) -> Result<Self::Client, String>;
     async fn send_request(&self, client: &Self::Client) -> RequestStats;
 }
 
@@ -104,7 +104,7 @@ impl BenchRun {
         bench_protocol_adapter: &impl BenchmarkProtocolAdapter,
         metrics_channel: Sender<RequestStats>,
     ) -> Result<(), String> {
-        let client = bench_protocol_adapter.build_client()?;
+        let client = bench_protocol_adapter.build_client().await?;
 
         while self.has_more_work() {
             self.rate_limiter.acquire_one().await;

--- a/src/bench_session.rs
+++ b/src/bench_session.rs
@@ -126,14 +126,15 @@ impl BenchBatch {
             let bench_protocol_adapter = self.mode.clone();
             let metrics_channel = metrics_sender.clone();
             concurrent_clients.push(tokio::spawn(async move {
-                bench_run
-                    .send_load(
-                        match bench_protocol_adapter.as_ref() {
-                            BenchmarkMode::Http(http_bench_session) => http_bench_session,
-                        },
-                        metrics_channel,
-                    )
-                    .await
+                match bench_protocol_adapter.as_ref() {
+                    BenchmarkMode::Http(adapter) => {
+                        bench_run.send_load(adapter, metrics_channel).await
+                    }
+                    #[cfg(feature = "http3")]
+                    BenchmarkMode::Http3(adapter) => {
+                        bench_run.send_load(adapter, metrics_channel).await
+                    }
+                }
             }));
         }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,4 +1,6 @@
 use crate::bench_session::{BenchSession, BenchSessionBuilder, RateLadder, RateLadderBuilder};
+#[cfg(feature = "http3")]
+use crate::h3_bench_session::{H3BenchAdapter, H3BenchAdapterBuilder};
 /// Copyright 2020 Developers of the perf-gauge project.
 ///
 /// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -27,6 +29,8 @@ use tokio::io;
 #[derive(Clone)]
 pub enum BenchmarkMode {
     Http(HttpBenchAdapter),
+    #[cfg(feature = "http3")]
+    Http3(H3BenchAdapter),
 }
 
 #[derive(Clone, Builder)]
@@ -125,6 +129,9 @@ struct HttpOptions {
     /// Enforce HTTP/2 only.
     #[arg(long = "http2_only")]
     http2_only: bool,
+    /// Use HTTP/3 (QUIC). Requires https:// URLs.
+    #[arg(long = "http3")]
+    http3: bool,
 }
 
 impl BenchmarkConfig {
@@ -257,6 +264,49 @@ impl BenchmarkConfig {
                     exit(-1);
                 }
 
+                let mut request_builder = HttpRequestBuilder::default();
+                request_builder
+                    .url(config.target.clone())
+                    .method(
+                        Method::from_bytes(
+                            config
+                                .method
+                                .as_ref()
+                                .map_or("GET", |s| s.as_str())
+                                .as_bytes(),
+                        )
+                        .expect("Invalid HTTP method"),
+                    )
+                    .headers(
+                        config
+                            .header
+                            .iter()
+                            .map(|s| {
+                                let mut split = s.split(':');
+                                (
+                                    split.next().expect("Header name is missing").to_string(),
+                                    split.map(String::from).collect::<Vec<String>>(),
+                                )
+                            })
+                            .collect(),
+                    )
+                    .body(BenchmarkConfig::generate_body(config));
+
+                #[cfg(feature = "http3")]
+                if config.http3 {
+                    if config.http2_only {
+                        eprintln!("Cannot use --http2_only with --http3");
+                        std::process::exit(1);
+                    }
+                    return BenchmarkConfig::build_h3_mode(config, request_builder);
+                }
+
+                #[cfg(not(feature = "http3"))]
+                if config.http3 {
+                    eprintln!("HTTP/3 is not enabled. Compile with --features http3");
+                    std::process::exit(1);
+                }
+
                 let http_config = HttpBenchAdapterBuilder::default()
                     .config(
                         HttpClientConfigBuilder::default()
@@ -267,44 +317,29 @@ impl BenchmarkConfig {
                             .build()
                             .expect("HttpClientConfigBuilder failed"),
                     )
-                    .request(
-                        HttpRequestBuilder::default()
-                            .url(config.target.clone())
-                            .method(
-                                Method::from_bytes(
-                                    config
-                                        .method
-                                        .as_ref()
-                                        .map_or("GET", |s| s.as_str())
-                                        .as_bytes(),
-                                )
-                                .expect("Invalid HTTP method"),
-                            )
-                            .headers(
-                                config
-                                    .header
-                                    .iter()
-                                    .map(|s| {
-                                        let mut split = s.split(':');
-                                        (
-                                            split
-                                                .next()
-                                                .expect("Header name is missing")
-                                                .to_string(),
-                                            split.map(String::from).collect::<Vec<String>>(),
-                                        )
-                                    })
-                                    .collect(),
-                            )
-                            .body(BenchmarkConfig::generate_body(config))
-                            .build()
-                            .expect("HttpRequestBuilder failed"),
-                    )
+                    .request(request_builder.build().expect("HttpRequestBuilder failed"))
                     .build()
                     .expect("BenchmarkModeBuilder failed");
                 BenchmarkMode::Http(http_config)
             }
         }
+    }
+
+    #[cfg(feature = "http3")]
+    fn build_h3_mode(config: &HttpOptions, request: HttpRequestBuilder) -> BenchmarkMode {
+        let h3_config = H3BenchAdapterBuilder::default()
+            .config(
+                HttpClientConfigBuilder::default()
+                    .ignore_cert(config.ignore_cert)
+                    .conn_reuse(config.conn_reuse)
+                    .stop_on_errors(config.error_stop.clone())
+                    .build()
+                    .expect("HttpClientConfigBuilder failed"),
+            )
+            .request(request.build().expect("HttpRequestBuilder failed"))
+            .build()
+            .expect("H3BenchAdapterBuilder failed");
+        BenchmarkMode::Http3(h3_config)
     }
 
     fn generate_body(args: &HttpOptions) -> Bytes {
@@ -373,6 +408,10 @@ impl fmt::Display for BenchmarkMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             BenchmarkMode::Http(mode) => {
+                writeln!(f, "{mode}")
+            }
+            #[cfg(feature = "http3")]
+            BenchmarkMode::Http3(mode) => {
                 writeln!(f, "{mode}")
             }
         }

--- a/src/h3_bench_session.rs
+++ b/src/h3_bench_session.rs
@@ -1,0 +1,300 @@
+/// Copyright 2020 Developers of the perf-gauge project.
+///
+/// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+/// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+/// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+/// option. This file may not be copied, modified, or distributed
+/// except according to those terms.
+use crate::bench_run::BenchmarkProtocolAdapter;
+use crate::http_bench_session::{HttpClientConfig, HttpRequest};
+use crate::metrics::{RequestStats, RequestStatsBuilder};
+use async_trait::async_trait;
+use bytes::{Buf, Bytes};
+use core::fmt;
+use derive_builder::Builder;
+use h3::client::SendRequest;
+use h3_quinn::quinn;
+use hyper::Request;
+use log::error;
+use rustls_pki_types::ServerName;
+use serde::Deserialize;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
+
+#[derive(Builder, Deserialize, Clone)]
+pub struct H3BenchAdapter {
+    config: HttpClientConfig,
+    request: HttpRequest,
+}
+
+/// A custom certificate verifier that accepts any server certificate.
+/// Used when `--ignore_cert` is specified.
+#[derive(Debug)]
+struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl SkipServerVerification {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(Arc::new(rustls::crypto::ring::default_provider())))
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls_pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls_pki_types::CertificateDer<'_>],
+        _server_name: &rustls_pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls_pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls_pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls_pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+impl H3BenchAdapter {
+    fn build_quinn_client_config(&self) -> quinn::ClientConfig {
+        let mut crypto_config = if self.config.ignore_cert {
+            rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(SkipServerVerification::new())
+                .with_no_client_auth()
+        } else {
+            let mut roots = rustls::RootCertStore::empty();
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth()
+        };
+
+        crypto_config.alpn_protocols = vec![b"h3".to_vec()];
+
+        let quic_config = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config)
+            .expect("Failed to create QuicClientConfig");
+        quinn::ClientConfig::new(Arc::new(quic_config))
+    }
+
+    /// Resolve a URL to (host, port, SocketAddr).
+    async fn resolve_target(url: &str) -> Result<(String, u16, SocketAddr), String> {
+        let parsed = url::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
+
+        if parsed.scheme() != "https" {
+            return Err("HTTP/3 requires https:// URLs".to_string());
+        }
+
+        let host = parsed.host_str().ok_or("URL must have a host")?.to_string();
+        let port = parsed.port().unwrap_or(443);
+
+        let addr = tokio::net::lookup_host(format!("{host}:{port}"))
+            .await
+            .map_err(|e| format!("DNS resolution failed: {e}"))?
+            .next()
+            .ok_or_else(|| format!("No addresses found for {host}:{port}"))?;
+
+        Ok((host, port, addr))
+    }
+}
+
+/// The h3 client handle used for benchmarking.
+/// Wraps the SendRequest handle plus connection metadata needed per-request.
+pub struct H3Client {
+    send_request: SendRequest<h3_quinn::OpenStreams, Bytes>,
+    /// Keep endpoint alive for the lifetime of the client.
+    _endpoint: quinn::Endpoint,
+}
+
+#[async_trait]
+impl BenchmarkProtocolAdapter for H3BenchAdapter {
+    type Client = H3Client;
+
+    async fn build_client(&self) -> Result<Self::Client, String> {
+        let first_url = self.request.first_url();
+        let (host, _port, addr) = Self::resolve_target(first_url).await?;
+
+        let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap())
+            .map_err(|e| format!("Failed to create QUIC endpoint: {e}"))?;
+        endpoint.set_default_client_config(self.build_quinn_client_config());
+
+        let server_name: ServerName<'_> = host
+            .as_str()
+            .try_into()
+            .map_err(|e| format!("Invalid server name: {e}"))?;
+
+        let connection = endpoint
+            .connect(addr, &server_name.to_str())
+            .map_err(|e| format!("QUIC connect error: {e}"))?
+            .await
+            .map_err(|e| format!("QUIC connection failed: {e}"))?;
+
+        let (mut driver, send_request) = h3::client::new(h3_quinn::Connection::new(connection))
+            .await
+            .map_err(|e| format!("H3 handshake failed: {e}"))?;
+
+        tokio::spawn(async move {
+            let e = futures_util::future::poll_fn(|cx| driver.poll_close(cx)).await;
+            error!("H3 connection closed: {:?}", e);
+        });
+
+        Ok(H3Client {
+            send_request,
+            _endpoint: endpoint,
+        })
+    }
+
+    async fn send_request(&self, client: &Self::Client) -> RequestStats {
+        let start = Instant::now();
+
+        let (url, method, headers, body) = self.request.request_parts();
+
+        let mut request_builder = Request::builder().method(method).uri(url);
+
+        for (name, value) in headers {
+            request_builder = request_builder.header(name, value);
+        }
+
+        let request = match request_builder.body(()) {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Failed to build H3 request: {}", e);
+                return RequestStatsBuilder::default()
+                    .bytes_processed(0)
+                    .status(e.to_string())
+                    .is_success(false)
+                    .duration(Instant::now().duration_since(start))
+                    .fatal_error(false)
+                    .build()
+                    .expect("RequestStatsBuilder failed");
+            }
+        };
+
+        // Clone the send_request handle — opens a new stream on the same QUIC connection
+        let mut send_request = client.send_request.clone();
+
+        match send_request.send_request(request).await {
+            Ok(mut stream) => {
+                // Send body if present
+                if !body.is_empty() {
+                    if let Err(e) = stream.send_data(body).await {
+                        error!("H3 send_data error: {}", e);
+                        return RequestStatsBuilder::default()
+                            .bytes_processed(0)
+                            .status(e.to_string())
+                            .is_success(false)
+                            .duration(Instant::now().duration_since(start))
+                            .fatal_error(false)
+                            .build()
+                            .expect("RequestStatsBuilder failed");
+                    }
+                }
+
+                // Signal end of request
+                if let Err(e) = stream.finish().await {
+                    error!("H3 finish error: {}", e);
+                    return RequestStatsBuilder::default()
+                        .bytes_processed(0)
+                        .status(e.to_string())
+                        .is_success(false)
+                        .duration(Instant::now().duration_since(start))
+                        .fatal_error(false)
+                        .build()
+                        .expect("RequestStatsBuilder failed");
+                }
+
+                // Receive response
+                match stream.recv_response().await {
+                    Ok(response) => {
+                        let status = response.status().to_string();
+                        let success = response.status().is_success();
+                        let fatal_error = !success
+                            && self
+                                .config
+                                .stop_on_errors
+                                .contains(&response.status().as_u16());
+
+                        // Read response body
+                        let mut total_size = 0;
+                        let mut body_error = false;
+                        while let Ok(Some(data)) = stream.recv_data().await {
+                            total_size += data.remaining();
+                        }
+
+                        // Check for stream errors after body
+                        if stream.recv_data().await.is_err() {
+                            body_error = true;
+                        }
+
+                        RequestStatsBuilder::default()
+                            .bytes_processed(total_size)
+                            .status(status)
+                            .is_success(success && !body_error)
+                            .duration(Instant::now().duration_since(start))
+                            .fatal_error(fatal_error)
+                            .build()
+                            .expect("RequestStatsBuilder failed")
+                    }
+                    Err(e) => {
+                        error!("H3 recv_response error: {}", e);
+                        RequestStatsBuilder::default()
+                            .bytes_processed(0)
+                            .status(e.to_string())
+                            .is_success(false)
+                            .duration(Instant::now().duration_since(start))
+                            .fatal_error(false)
+                            .build()
+                            .expect("RequestStatsBuilder failed")
+                    }
+                }
+            }
+            Err(e) => {
+                error!("H3 send_request error: {}", e);
+                let status = e.to_string();
+                RequestStatsBuilder::default()
+                    .bytes_processed(0)
+                    .status(status)
+                    .is_success(false)
+                    .duration(Instant::now().duration_since(start))
+                    .fatal_error(false)
+                    .build()
+                    .expect("RequestStatsBuilder failed")
+            }
+        }
+    }
+}
+
+impl fmt::Display for H3BenchAdapter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "H3 Config={:?}, Request={}", self.config, self.request)
+    }
+}

--- a/src/http_bench_session.rs
+++ b/src/http_bench_session.rs
@@ -32,13 +32,14 @@ use std::time::Instant;
 use tokio_native_tls::TlsConnector;
 
 #[derive(Builder, Deserialize, Clone, Debug)]
+#[allow(dead_code)]
 pub struct HttpClientConfig {
     #[builder(default)]
-    ignore_cert: bool,
+    pub ignore_cert: bool,
     #[builder(default)]
-    conn_reuse: bool,
+    pub conn_reuse: bool,
     #[builder(default)]
-    http2_only: bool,
+    pub http2_only: bool,
     #[builder(default)]
     pub stop_on_errors: Vec<u16>,
 }
@@ -126,7 +127,7 @@ impl HttpBenchAdapter {
 impl BenchmarkProtocolAdapter for HttpBenchAdapter {
     type Client = Client<ProtocolConnector, Full<Bytes>>;
 
-    fn build_client(&self) -> Result<Self::Client, String> {
+    async fn build_client(&self) -> Result<Self::Client, String> {
         Ok(Client::builder(TokioExecutor::new())
             .http2_only(self.config.http2_only)
             .pool_max_idle_per_host(if !self.config.conn_reuse {
@@ -225,6 +226,35 @@ impl HttpRequest {
                 .expect("Error building Request")
         }
     }
+
+    /// Get the first URL (for connection establishment in HTTP/3).
+    #[cfg(feature = "http3")]
+    pub fn first_url(&self) -> &str {
+        &self.url[0]
+    }
+
+    /// Get request parts for building protocol-specific requests.
+    /// Returns (url, method, headers, body) with a random URL and random header values selected.
+    #[cfg(feature = "http3")]
+    pub fn request_parts(&self) -> (&str, Method, Vec<(&str, &str)>, Bytes) {
+        use rand::{thread_rng, Rng};
+
+        let url = &self.url[thread_rng().gen_range(0..self.url.len())];
+        let method = self.method.clone();
+
+        let headers: Vec<(&str, &str)> = self
+            .headers
+            .iter()
+            .map(|(key, values)| {
+                let value = &values[thread_rng().gen_range(0..values.len())];
+                (key.as_str(), value.as_str())
+            })
+            .collect();
+
+        let body = self.body.clone();
+
+        (url, method, headers, body)
+    }
 }
 
 impl HttpRequestBuilder {
@@ -299,7 +329,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let client = http_bench.build_client().expect("Client is built");
+        let client = http_bench.build_client().await.expect("Client is built");
         let stats = http_bench.send_request(&client).await;
 
         println!("{stats:?}");
@@ -342,7 +372,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let client = http_bench.build_client().expect("Client is built");
+        let client = http_bench.build_client().await.expect("Client is built");
         let stats = http_bench.send_request(&client).await;
 
         println!("{stats:?}");
@@ -385,7 +415,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let client = http_bench.build_client().expect("Client is built");
+        let client = http_bench.build_client().await.expect("Client is built");
         let stats = http_bench.send_request(&client).await;
 
         println!("{stats:?}");
@@ -435,7 +465,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let client = http_bench.build_client().expect("Client is built");
+        let client = http_bench.build_client().await.expect("Client is built");
 
         for _ in 0..128 {
             http_bench.send_request(&client).await;
@@ -471,7 +501,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let client = http_bench.build_client().expect("Client is built");
+        let client = http_bench.build_client().await.expect("Client is built");
         let stats = http_bench.send_request(&client).await;
 
         println!("{stats:?}");
@@ -510,7 +540,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let client = http_bench.build_client().expect("Client is built");
+        let client = http_bench.build_client().await.expect("Client is built");
         let result = timeout(Duration::from_secs(1), http_bench.send_request(&client)).await;
 
         let failed = match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@
 mod bench_run;
 mod bench_session;
 mod configuration;
+#[cfg(feature = "http3")]
+mod h3_bench_session;
 mod http_bench_session;
 mod metrics;
 #[cfg(feature = "report-to-prometheus")]


### PR DESCRIPTION
## Summary

Add HTTP/3 transport via `h3`/`quinn`/`rustls` behind the `http3` feature flag.

## Changes

### New: `H3BenchAdapter` (`src/h3_bench_session.rs`)
- Full implementation of `BenchmarkProtocolAdapter` for HTTP/3 over QUIC
- QUIC connection via `quinn`, HTTP/3 via `h3`/`h3-quinn`
- TLS via `rustls` with `webpki-roots`
- Supports `--ignore_cert` via custom `ServerCertVerifier`
- Background h3 connection driver task

### Modified: `BenchmarkProtocolAdapter` trait
- `build_client()` is now `async fn` (required for QUIC connection establishment)
- All existing call sites updated

### CLI
- New `--http3` flag on the `http` subcommand
- Validates: cannot combine `--http3` with `--http2_only`
- Graceful error if compiled without `--features http3`

### Dependencies (all optional, gated behind `http3` feature)
- `h3 0.0.8`, `h3-quinn 0.0.10`, `quinn 0.11`
- `rustls 0.23`, `rustls-pki-types 1`, `webpki-roots 0.26`
- `futures-util 0.3`, `url 2`

### CI
- Added `http3` feature to clippy and test workflows

## Usage
```bash
cargo build --features http3
perf-gauge -c 4 -d 10s http --http3 https://example.com
```

## Local Verification
- ✅ `cargo fmt --check`
- ✅ `cargo clippy --tests -- -D warnings` (default, full, http3)
- ✅ `cargo test` (default, http3) — 27/27 pass